### PR TITLE
Better support for narrow displays, make sure no image is wider

### DIFF
--- a/src/app/components/photo-album/photo-album.component.html
+++ b/src/app/components/photo-album/photo-album.component.html
@@ -1,11 +1,10 @@
 <div class="album-container">
     @for(photo of photos$ | async; track photo) {
     <div class="photo-container">
-        <img 
+        <img class="photo"
             src="{{ getPreviewImagePath(photo, 1) }}"
             srcset="{{ getPreviewImagePath(photo, 2) }} 2x"
-            alt="{{ photo.name }}"
-            width="{{ previewWidth$ | async }}">
+            alt="{{ photo.name }}">
     </div>
     }
 </div>

--- a/src/app/components/photo-album/photo-album.component.scss
+++ b/src/app/components/photo-album/photo-album.component.scss
@@ -3,11 +3,15 @@
     margin-left: auto;
     margin-right: auto;
     display: grid;
-    grid-template-columns: repeat(auto-fill, 600px);
+    grid-template-columns: repeat(auto-fill, min(600px, 90vw));
     column-gap: 6px;
 }
 .photo-container {
-    // width will be set on the image
     width: auto;
     height: auto;
+}
+.photo {
+    width: min(600px, 90vw);
+    height: calc(min(600px, 90vw) * 0.75);
+    border-radius: 6px;
 }

--- a/src/app/components/photo-albums/photo-albums.component.html
+++ b/src/app/components/photo-albums/photo-albums.component.html
@@ -3,10 +3,10 @@
     <div class="album-container">
         <div class="thumbnail-container">
             <a [routerLink]="['/albums', album.path]">
-                <img src="{{ getThumbnailImagePath(albums, album, thumbnailWidth$.value ) }}"
+                <img class="preview" 
+                     src="{{ getThumbnailImagePath(albums, album, thumbnailWidth$.value ) }}"
                      srcset="{{ getThumbnailImagePath(albums, album, thumbnailWidth$.value * 2) }} 2x"
-                     alt="{{ album.description }}"
-                     width="{{ thumbnailWidth$ | async }}">
+                     alt="{{ album.description }}">
             </a>
         </div>
         <div class="album-summary">

--- a/src/app/components/photo-albums/photo-albums.component.scss
+++ b/src/app/components/photo-albums/photo-albums.component.scss
@@ -3,7 +3,7 @@
     margin-left: auto;
     margin-right: auto;
     display: grid;
-    grid-template-columns: repeat(auto-fill, 300px);
+    grid-template-columns: repeat(auto-fill, min(300px, 90vw));
     column-gap: 6px;
 }
 .album-container {
@@ -23,4 +23,8 @@
 }
 .album-name {
     font-size: 13px;
+}
+.preview {
+    width: min(300px, 90vw);
+    height: calc(min(300px, 90vw) * 0.75);
 }


### PR DESCRIPTION
than the top-level containers (90vw).  Use calc to set height explicitly to avoid layout changes.